### PR TITLE
Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ travis-ci = {repository = "sile/beam_file"}
 codecov = {repository = "sile/beam_file"}
 
 [dependencies]
+thiserror = "^1"
 byteorder = "1.2"
 libflate = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ codecov = {repository = "sile/beam_file"}
 [dependencies]
 thiserror = "^1"
 byteorder = "1.2"
-libflate = "0.1"
+libflate = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "beam_file"
 version = "0.2.4"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]

--- a/src/beam_file.rs
+++ b/src/beam_file.rs
@@ -21,12 +21,12 @@ pub struct BeamFile<C> {
 }
 impl<C: Chunk> BeamFile<C> {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let f = r#try!(File::open(path));
+        let f = File::open(path)?;
         Self::from_reader(f)
     }
     pub fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
         let expected = Header::new(0);
-        let header = r#try!(Header::from_reader(&mut reader));
+        let header = Header::from_reader(&mut reader)?;
         if header.magic_number != expected.magic_number {
             return Err(Error::UnexpectedMagicNumber {
                 magic_number: header.magic_number,
@@ -39,29 +39,29 @@ impl<C: Chunk> BeamFile<C> {
         }
 
         let mut buf = vec![0; (header.payload_size - 4) as usize];
-        r#try!(reader.read_exact(&mut buf));
+        reader.read_exact(&mut buf)?;
 
         let mut chunks = Vec::new();
         let mut cursor = Cursor::new(&buf);
         while cursor.position() < buf.len() as u64 {
-            chunks.push(r#try!(C::decode(&mut cursor)));
+            chunks.push(C::decode(&mut cursor)?);
         }
         Ok(BeamFile { chunks })
     }
 
     pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        let f = r#try!(File::create(path));
+        let f = File::create(path)?;
         self.to_writer(f)
     }
     pub fn to_writer<W: Write>(&self, mut writer: W) -> Result<()> {
         let mut buf = Vec::new();
         for chunk in &self.chunks {
-            r#try!(chunk.encode(&mut buf));
+            chunk.encode(&mut buf)?;
         }
 
         let header = Header::new(buf.len() as u32 + 4);
-        r#try!(header.to_writer(&mut writer));
-        r#try!(writer.write_all(&buf));
+        header.to_writer(&mut writer)?;
+        writer.write_all(&buf)?;
         Ok(())
     }
 }
@@ -81,15 +81,15 @@ impl Header {
     }
     fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
         let mut header = Self::new(0);
-        r#try!(reader.read_exact(&mut header.magic_number));
-        header.payload_size = r#try!(reader.read_u32::<BigEndian>());
-        r#try!(reader.read_exact(&mut header.type_id));
+        reader.read_exact(&mut header.magic_number)?;
+        header.payload_size = reader.read_u32::<BigEndian>()?;
+        reader.read_exact(&mut header.type_id)?;
         Ok(header)
     }
     fn to_writer<W: Write>(&self, mut writer: W) -> Result<()> {
-        r#try!(writer.write_all(&self.magic_number));
-        r#try!(writer.write_u32::<BigEndian>(self.payload_size));
-        r#try!(writer.write_all(&self.type_id));
+        writer.write_all(&self.magic_number)?;
+        writer.write_u32::<BigEndian>(self.payload_size)?;
+        writer.write_all(&self.type_id)?;
         Ok(())
     }
 }

--- a/src/beam_file.rs
+++ b/src/beam_file.rs
@@ -3,8 +3,8 @@ use std::fs::File;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
 
-use chunk::Chunk;
-use {Error, Result};
+use crate::chunk::Chunk;
+use crate::{Error, Result};
 
 /// A BEAM File
 ///
@@ -21,12 +21,12 @@ pub struct BeamFile<C> {
 }
 impl<C: Chunk> BeamFile<C> {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let f = try!(File::open(path));
+        let f = r#try!(File::open(path));
         Self::from_reader(f)
     }
     pub fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
         let expected = Header::new(0);
-        let header = try!(Header::from_reader(&mut reader));
+        let header = r#try!(Header::from_reader(&mut reader));
         if header.magic_number != expected.magic_number {
             return Err(Error::UnexpectedMagicNumber {
                 magic_number: header.magic_number,
@@ -39,29 +39,29 @@ impl<C: Chunk> BeamFile<C> {
         }
 
         let mut buf = vec![0; (header.payload_size - 4) as usize];
-        try!(reader.read_exact(&mut buf));
+        r#try!(reader.read_exact(&mut buf));
 
         let mut chunks = Vec::new();
         let mut cursor = Cursor::new(&buf);
         while cursor.position() < buf.len() as u64 {
-            chunks.push(try!(C::decode(&mut cursor)));
+            chunks.push(r#try!(C::decode(&mut cursor)));
         }
         Ok(BeamFile { chunks })
     }
 
     pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        let f = try!(File::create(path));
+        let f = r#try!(File::create(path));
         self.to_writer(f)
     }
     pub fn to_writer<W: Write>(&self, mut writer: W) -> Result<()> {
         let mut buf = Vec::new();
         for chunk in &self.chunks {
-            try!(chunk.encode(&mut buf));
+            r#try!(chunk.encode(&mut buf));
         }
 
         let header = Header::new(buf.len() as u32 + 4);
-        try!(header.to_writer(&mut writer));
-        try!(writer.write_all(&buf));
+        r#try!(header.to_writer(&mut writer));
+        r#try!(writer.write_all(&buf));
         Ok(())
     }
 }
@@ -81,15 +81,15 @@ impl Header {
     }
     fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
         let mut header = Self::new(0);
-        try!(reader.read_exact(&mut header.magic_number));
-        header.payload_size = try!(reader.read_u32::<BigEndian>());
-        try!(reader.read_exact(&mut header.type_id));
+        r#try!(reader.read_exact(&mut header.magic_number));
+        header.payload_size = r#try!(reader.read_u32::<BigEndian>());
+        r#try!(reader.read_exact(&mut header.type_id));
         Ok(header)
     }
     fn to_writer<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.magic_number));
-        try!(writer.write_u32::<BigEndian>(self.payload_size));
-        try!(writer.write_all(&self.type_id));
+        r#try!(writer.write_all(&self.magic_number));
+        r#try!(writer.write_u32::<BigEndian>(self.payload_size));
+        r#try!(writer.write_all(&self.type_id));
         Ok(())
     }
 }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -10,8 +10,8 @@ use libflate::zlib;
 use std::io::{Cursor, Read, Write};
 use std::str;
 
-use parts;
-use Result;
+use crate::parts;
+use crate::Result;
 
 /// The identifier which indicates the type of a chunk.
 pub type Id = [u8; 4];
@@ -26,11 +26,11 @@ pub trait Chunk {
     where
         Self: Sized,
     {
-        let header = try!(aux::Header::decode(&mut reader));
+        let header = r#try!(aux::Header::decode(&mut reader));
         let mut buf = vec![0; header.data_size as usize];
-        try!(reader.read_exact(&mut buf));
+        r#try!(reader.read_exact(&mut buf));
         for _ in 0..aux::padding_size(header.data_size) {
-            try!(reader.read_u8());
+            r#try!(reader.read_u8());
         }
 
         Self::decode_data(&header.chunk_id, Cursor::new(&buf))
@@ -46,11 +46,11 @@ pub trait Chunk {
     /// Writes the chunk to `writer`.
     fn encode<W: Write>(&self, mut writer: W) -> Result<()> {
         let mut buf = Vec::new();
-        try!(self.encode_data(&mut buf));
-        try!(aux::Header::new(self.id(), buf.len() as u32).encode(&mut writer,));
-        try!(writer.write_all(&buf));
+        r#try!(self.encode_data(&mut buf));
+        r#try!(aux::Header::new(self.id(), buf.len() as u32).encode(&mut writer,));
+        r#try!(writer.write_all(&buf));
         for _ in 0..aux::padding_size(buf.len() as u32) {
-            try!(writer.write_u8(0));
+            r#try!(writer.write_u8(0));
         }
         Ok(())
     }
@@ -83,11 +83,11 @@ impl Chunk for RawChunk {
         Self: Sized,
     {
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(RawChunk { id: *id, data: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.data));
+        r#try!(writer.write_all(&self.data));
         Ok(())
     }
 }
@@ -116,19 +116,19 @@ impl Chunk for AtomChunk {
         let unicode;
         match aux::check_chunk_id(id, b"Atom") {
             Err(_) => {
-                try!(aux::check_chunk_id(id, b"AtU8"));
+                r#try!(aux::check_chunk_id(id, b"AtU8"));
                 unicode = true;
             }
             Ok(_) => unicode = false,
         }
-        let count = try!(reader.read_u32::<BigEndian>()) as usize;
+        let count = r#try!(reader.read_u32::<BigEndian>()) as usize;
         let mut atoms = Vec::with_capacity(count);
         for _ in 0..count {
-            let len = try!(reader.read_u8()) as usize;
+            let len = r#try!(reader.read_u8()) as usize;
             let mut buf = vec![0; len];
-            try!(reader.read_exact(&mut buf));
+            r#try!(reader.read_exact(&mut buf));
 
-            let name = try!(str::from_utf8(&buf).map(|s| s.to_string()));
+            let name = r#try!(str::from_utf8(&buf).map(|s| s.to_string()));
             atoms.push(parts::Atom {
                 name: name.to_string(),
             });
@@ -139,11 +139,11 @@ impl Chunk for AtomChunk {
         })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_u32::<BigEndian>(self.atoms.len() as u32));
+        r#try!(writer.write_u32::<BigEndian>(self.atoms.len() as u32));
         for atom in &self.atoms {
             assert!(atom.name.len() < 0x100);
-            try!(writer.write_u8(atom.name.len() as u8));
-            try!(writer.write_all(atom.name.as_bytes()));
+            r#try!(writer.write_u8(atom.name.len() as u8));
+            r#try!(writer.write_all(atom.name.as_bytes()));
         }
         Ok(())
     }
@@ -178,25 +178,25 @@ impl Chunk for CodeChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"Code"));
+        r#try!(aux::check_chunk_id(id, b"Code"));
         let mut code = CodeChunk {
-            info_size: try!(reader.read_u32::<BigEndian>()),
-            version: try!(reader.read_u32::<BigEndian>()),
-            opcode_max: try!(reader.read_u32::<BigEndian>()),
-            label_count: try!(reader.read_u32::<BigEndian>()),
-            function_count: try!(reader.read_u32::<BigEndian>()),
+            info_size: r#try!(reader.read_u32::<BigEndian>()),
+            version: r#try!(reader.read_u32::<BigEndian>()),
+            opcode_max: r#try!(reader.read_u32::<BigEndian>()),
+            label_count: r#try!(reader.read_u32::<BigEndian>()),
+            function_count: r#try!(reader.read_u32::<BigEndian>()),
             bytecode: Vec::new(),
         };
-        try!(reader.read_to_end(&mut code.bytecode));
+        r#try!(reader.read_to_end(&mut code.bytecode));
         Ok(code)
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_u32::<BigEndian>(self.info_size));
-        try!(writer.write_u32::<BigEndian>(self.version));
-        try!(writer.write_u32::<BigEndian>(self.opcode_max));
-        try!(writer.write_u32::<BigEndian>(self.label_count));
-        try!(writer.write_u32::<BigEndian>(self.function_count));
-        try!(writer.write_all(&self.bytecode));
+        r#try!(writer.write_u32::<BigEndian>(self.info_size));
+        r#try!(writer.write_u32::<BigEndian>(self.version));
+        r#try!(writer.write_u32::<BigEndian>(self.opcode_max));
+        r#try!(writer.write_u32::<BigEndian>(self.label_count));
+        r#try!(writer.write_u32::<BigEndian>(self.function_count));
+        r#try!(writer.write_all(&self.bytecode));
         Ok(())
     }
 }
@@ -215,13 +215,13 @@ impl Chunk for StrTChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"StrT"));
+        r#try!(aux::check_chunk_id(id, b"StrT"));
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(StrTChunk { strings: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.strings));
+        r#try!(writer.write_all(&self.strings));
         Ok(())
     }
 }
@@ -240,24 +240,24 @@ impl Chunk for ImpTChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"ImpT"));
-        let count = try!(reader.read_u32::<BigEndian>()) as usize;
+        r#try!(aux::check_chunk_id(id, b"ImpT"));
+        let count = r#try!(reader.read_u32::<BigEndian>()) as usize;
         let mut imports = Vec::with_capacity(count);
         for _ in 0..count {
             imports.push(parts::Import {
-                module: try!(reader.read_u32::<BigEndian>()),
-                function: try!(reader.read_u32::<BigEndian>()),
-                arity: try!(reader.read_u32::<BigEndian>()),
+                module: r#try!(reader.read_u32::<BigEndian>()),
+                function: r#try!(reader.read_u32::<BigEndian>()),
+                arity: r#try!(reader.read_u32::<BigEndian>()),
             });
         }
         Ok(ImpTChunk { imports })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_u32::<BigEndian>(self.imports.len() as u32));
+        r#try!(writer.write_u32::<BigEndian>(self.imports.len() as u32));
         for import in &self.imports {
-            try!(writer.write_u32::<BigEndian>(import.module));
-            try!(writer.write_u32::<BigEndian>(import.function));
-            try!(writer.write_u32::<BigEndian>(import.arity));
+            r#try!(writer.write_u32::<BigEndian>(import.module));
+            r#try!(writer.write_u32::<BigEndian>(import.function));
+            r#try!(writer.write_u32::<BigEndian>(import.arity));
         }
         Ok(())
     }
@@ -277,24 +277,24 @@ impl Chunk for ExpTChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"ExpT"));
-        let count = try!(reader.read_u32::<BigEndian>()) as usize;
+        r#try!(aux::check_chunk_id(id, b"ExpT"));
+        let count = r#try!(reader.read_u32::<BigEndian>()) as usize;
         let mut exports = Vec::with_capacity(count);
         for _ in 0..count {
             exports.push(parts::Export {
-                function: try!(reader.read_u32::<BigEndian>()),
-                arity: try!(reader.read_u32::<BigEndian>()),
-                label: try!(reader.read_u32::<BigEndian>()),
+                function: r#try!(reader.read_u32::<BigEndian>()),
+                arity: r#try!(reader.read_u32::<BigEndian>()),
+                label: r#try!(reader.read_u32::<BigEndian>()),
             });
         }
         Ok(ExpTChunk { exports })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_u32::<BigEndian>(self.exports.len() as u32));
+        r#try!(writer.write_u32::<BigEndian>(self.exports.len() as u32));
         for export in &self.exports {
-            try!(writer.write_u32::<BigEndian>(export.function));
-            try!(writer.write_u32::<BigEndian>(export.arity));
-            try!(writer.write_u32::<BigEndian>(export.label));
+            r#try!(writer.write_u32::<BigEndian>(export.function));
+            r#try!(writer.write_u32::<BigEndian>(export.arity));
+            r#try!(writer.write_u32::<BigEndian>(export.label));
         }
         Ok(())
     }
@@ -317,16 +317,16 @@ impl Chunk for LitTChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"LitT"));
-        let _uncompressed_size = try!(reader.read_u32::<BigEndian>());
-        let mut decoder = try!(zlib::Decoder::new(reader));
+        r#try!(aux::check_chunk_id(id, b"LitT"));
+        let _uncompressed_size = r#try!(reader.read_u32::<BigEndian>());
+        let mut decoder = r#try!(zlib::Decoder::new(reader));
 
-        let count = try!(decoder.read_u32::<BigEndian>()) as usize;
+        let count = r#try!(decoder.read_u32::<BigEndian>()) as usize;
         let mut literals = Vec::with_capacity(count);
         for _ in 0..count {
-            let literal_size = try!(decoder.read_u32::<BigEndian>()) as usize;
+            let literal_size = r#try!(decoder.read_u32::<BigEndian>()) as usize;
             let mut buf = vec![0; literal_size];
-            try!(decoder.read_exact(&mut buf));
+            r#try!(decoder.read_exact(&mut buf));
             literals.push(buf);
         }
         Ok(LitTChunk { literals })
@@ -336,15 +336,15 @@ impl Chunk for LitTChunk {
             .literals
             .iter()
             .fold(4, |acc, l| acc + 4 + l.len() as u32);
-        try!(writer.write_u32::<BigEndian>(uncompressed_size));
+        r#try!(writer.write_u32::<BigEndian>(uncompressed_size));
 
-        let mut encoder = try!(zlib::Encoder::new(writer));
-        try!(encoder.write_u32::<BigEndian>(self.literals.len() as u32));
+        let mut encoder = r#try!(zlib::Encoder::new(writer));
+        r#try!(encoder.write_u32::<BigEndian>(self.literals.len() as u32));
         for literal in &self.literals {
-            try!(encoder.write_u32::<BigEndian>(literal.len() as u32));
-            try!(encoder.write_all(literal));
+            r#try!(encoder.write_u32::<BigEndian>(literal.len() as u32));
+            r#try!(encoder.write_all(literal));
         }
-        try!(encoder.finish().into_result());
+        r#try!(encoder.finish().into_result());
         Ok(())
     }
 }
@@ -363,24 +363,24 @@ impl Chunk for LocTChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"LocT"));
-        let count = try!(reader.read_u32::<BigEndian>()) as usize;
+        r#try!(aux::check_chunk_id(id, b"LocT"));
+        let count = r#try!(reader.read_u32::<BigEndian>()) as usize;
         let mut locals = Vec::with_capacity(count);
         for _ in 0..count {
             locals.push(parts::Local {
-                function: try!(reader.read_u32::<BigEndian>()),
-                arity: try!(reader.read_u32::<BigEndian>()),
-                label: try!(reader.read_u32::<BigEndian>()),
+                function: r#try!(reader.read_u32::<BigEndian>()),
+                arity: r#try!(reader.read_u32::<BigEndian>()),
+                label: r#try!(reader.read_u32::<BigEndian>()),
             });
         }
         Ok(LocTChunk { locals })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_u32::<BigEndian>(self.locals.len() as u32));
+        r#try!(writer.write_u32::<BigEndian>(self.locals.len() as u32));
         for local in &self.locals {
-            try!(writer.write_u32::<BigEndian>(local.function));
-            try!(writer.write_u32::<BigEndian>(local.arity));
-            try!(writer.write_u32::<BigEndian>(local.label));
+            r#try!(writer.write_u32::<BigEndian>(local.function));
+            r#try!(writer.write_u32::<BigEndian>(local.arity));
+            r#try!(writer.write_u32::<BigEndian>(local.label));
         }
         Ok(())
     }
@@ -400,30 +400,30 @@ impl Chunk for FunTChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"FunT"));
-        let count = try!(reader.read_u32::<BigEndian>()) as usize;
+        r#try!(aux::check_chunk_id(id, b"FunT"));
+        let count = r#try!(reader.read_u32::<BigEndian>()) as usize;
         let mut functions = Vec::with_capacity(count);
         for _ in 0..count {
             functions.push(parts::Function {
-                function: try!(reader.read_u32::<BigEndian>()),
-                arity: try!(reader.read_u32::<BigEndian>()),
-                label: try!(reader.read_u32::<BigEndian>()),
-                index: try!(reader.read_u32::<BigEndian>()),
-                num_free: try!(reader.read_u32::<BigEndian>()),
-                old_uniq: try!(reader.read_u32::<BigEndian>()),
+                function: r#try!(reader.read_u32::<BigEndian>()),
+                arity: r#try!(reader.read_u32::<BigEndian>()),
+                label: r#try!(reader.read_u32::<BigEndian>()),
+                index: r#try!(reader.read_u32::<BigEndian>()),
+                num_free: r#try!(reader.read_u32::<BigEndian>()),
+                old_uniq: r#try!(reader.read_u32::<BigEndian>()),
             });
         }
         Ok(FunTChunk { functions })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_u32::<BigEndian>(self.functions.len() as u32));
+        r#try!(writer.write_u32::<BigEndian>(self.functions.len() as u32));
         for f in &self.functions {
-            try!(writer.write_u32::<BigEndian>(f.function));
-            try!(writer.write_u32::<BigEndian>(f.arity));
-            try!(writer.write_u32::<BigEndian>(f.label));
-            try!(writer.write_u32::<BigEndian>(f.index));
-            try!(writer.write_u32::<BigEndian>(f.num_free));
-            try!(writer.write_u32::<BigEndian>(f.old_uniq));
+            r#try!(writer.write_u32::<BigEndian>(f.function));
+            r#try!(writer.write_u32::<BigEndian>(f.arity));
+            r#try!(writer.write_u32::<BigEndian>(f.label));
+            r#try!(writer.write_u32::<BigEndian>(f.index));
+            r#try!(writer.write_u32::<BigEndian>(f.num_free));
+            r#try!(writer.write_u32::<BigEndian>(f.old_uniq));
         }
         Ok(())
     }
@@ -448,13 +448,13 @@ impl Chunk for AttrChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"Attr"));
+        r#try!(aux::check_chunk_id(id, b"Attr"));
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(AttrChunk { term: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.term));
+        r#try!(writer.write_all(&self.term));
         Ok(())
     }
 }
@@ -478,13 +478,13 @@ impl Chunk for CInfChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"CInf"));
+        r#try!(aux::check_chunk_id(id, b"CInf"));
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(CInfChunk { term: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.term));
+        r#try!(writer.write_all(&self.term));
         Ok(())
     }
 }
@@ -507,13 +507,13 @@ impl Chunk for AbstChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"Abst"));
+        r#try!(aux::check_chunk_id(id, b"Abst"));
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(AbstChunk { term: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.term));
+        r#try!(writer.write_all(&self.term));
         Ok(())
     }
 }
@@ -546,13 +546,13 @@ impl Chunk for DbgiChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"Dbgi"));
+        r#try!(aux::check_chunk_id(id, b"Dbgi"));
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(DbgiChunk { term: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.term));
+        r#try!(writer.write_all(&self.term));
         Ok(())
     }
 }
@@ -596,13 +596,13 @@ impl Chunk for DocsChunk {
     where
         Self: Sized,
     {
-        try!(aux::check_chunk_id(id, b"Docs"));
+        r#try!(aux::check_chunk_id(id, b"Docs"));
         let mut buf = Vec::new();
-        try!(reader.read_to_end(&mut buf));
+        r#try!(reader.read_to_end(&mut buf));
         Ok(DocsChunk { term: buf })
     }
     fn encode_data<W: Write>(&self, mut writer: W) -> Result<()> {
-        try!(writer.write_all(&self.term));
+        r#try!(writer.write_all(&self.term));
         Ok(())
     }
 }
@@ -659,21 +659,21 @@ impl Chunk for StandardChunk {
     {
         use self::StandardChunk::*;
         match id {
-            b"Atom" => Ok(Atom(try!(AtomChunk::decode_data(id, reader)))),
-            b"AtU8" => Ok(Atom(try!(AtomChunk::decode_data(id, reader)))),
-            b"Code" => Ok(Code(try!(CodeChunk::decode_data(id, reader)))),
-            b"StrT" => Ok(StrT(try!(StrTChunk::decode_data(id, reader)))),
-            b"ImpT" => Ok(ImpT(try!(ImpTChunk::decode_data(id, reader)))),
-            b"ExpT" => Ok(ExpT(try!(ExpTChunk::decode_data(id, reader)))),
-            b"LitT" => Ok(LitT(try!(LitTChunk::decode_data(id, reader)))),
-            b"LocT" => Ok(LocT(try!(LocTChunk::decode_data(id, reader)))),
-            b"FunT" => Ok(FunT(try!(FunTChunk::decode_data(id, reader)))),
-            b"Attr" => Ok(Attr(try!(AttrChunk::decode_data(id, reader)))),
-            b"CInf" => Ok(CInf(try!(CInfChunk::decode_data(id, reader)))),
-            b"Abst" => Ok(Abst(try!(AbstChunk::decode_data(id, reader)))),
-            b"Dbgi" => Ok(Dbgi(try!(DbgiChunk::decode_data(id, reader)))),
-            b"Docs" => Ok(Docs(try!(DocsChunk::decode_data(id, reader)))),
-            _ => Ok(Unknown(try!(RawChunk::decode_data(id, reader)))),
+            b"Atom" => Ok(Atom(r#try!(AtomChunk::decode_data(id, reader)))),
+            b"AtU8" => Ok(Atom(r#try!(AtomChunk::decode_data(id, reader)))),
+            b"Code" => Ok(Code(r#try!(CodeChunk::decode_data(id, reader)))),
+            b"StrT" => Ok(StrT(r#try!(StrTChunk::decode_data(id, reader)))),
+            b"ImpT" => Ok(ImpT(r#try!(ImpTChunk::decode_data(id, reader)))),
+            b"ExpT" => Ok(ExpT(r#try!(ExpTChunk::decode_data(id, reader)))),
+            b"LitT" => Ok(LitT(r#try!(LitTChunk::decode_data(id, reader)))),
+            b"LocT" => Ok(LocT(r#try!(LocTChunk::decode_data(id, reader)))),
+            b"FunT" => Ok(FunT(r#try!(FunTChunk::decode_data(id, reader)))),
+            b"Attr" => Ok(Attr(r#try!(AttrChunk::decode_data(id, reader)))),
+            b"CInf" => Ok(CInf(r#try!(CInfChunk::decode_data(id, reader)))),
+            b"Abst" => Ok(Abst(r#try!(AbstChunk::decode_data(id, reader)))),
+            b"Dbgi" => Ok(Dbgi(r#try!(DbgiChunk::decode_data(id, reader)))),
+            b"Docs" => Ok(Docs(r#try!(DocsChunk::decode_data(id, reader)))),
+            _ => Ok(Unknown(r#try!(RawChunk::decode_data(id, reader)))),
         }
     }
     fn encode_data<W: Write>(&self, writer: W) -> Result<()> {
@@ -717,13 +717,13 @@ mod aux {
         }
         pub fn decode<R: io::Read>(mut reader: R) -> io::Result<Self> {
             let mut id = [0; 4];
-            try!(reader.read_exact(&mut id));
-            let size = try!(reader.read_u32::<BigEndian>());
+            r#try!(reader.read_exact(&mut id));
+            let size = r#try!(reader.read_u32::<BigEndian>());
             Ok(Header::new(&id, size))
         }
         pub fn encode<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
-            try!(writer.write_all(&self.chunk_id));
-            try!(writer.write_u32::<BigEndian>(self.data_size));
+            r#try!(writer.write_all(&self.chunk_id));
+            r#try!(writer.write_u32::<BigEndian>(self.data_size));
             Ok(())
         }
     }
@@ -732,9 +732,9 @@ mod aux {
         (4 - data_size % 4) % 4
     }
 
-    pub fn check_chunk_id(passed: &Id, expected: &Id) -> ::Result<()> {
+    pub fn check_chunk_id(passed: &Id, expected: &Id) -> crate::Result<()> {
         if passed != expected {
-            Err(::Error::UnexpectedChunk {
+            Err(crate::Error::UnexpectedChunk {
                 id: *passed,
                 expected: *expected,
             })

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -47,7 +47,7 @@ pub trait Chunk {
     fn encode<W: Write>(&self, mut writer: W) -> Result<()> {
         let mut buf = Vec::new();
         self.encode_data(&mut buf)?;
-        aux::Header::new(self.id(), buf.len() as u32).encode(&mut writer,)?;
+        aux::Header::new(self.id(), buf.len() as u32).encode(&mut writer)?;
         writer.write_all(&buf)?;
         for _ in 0..aux::padding_size(buf.len() as u32) {
             writer.write_u8(0)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+use std::io::Error as IoError;
+use std::str::Utf8Error;
+
+use crate::chunk::Id as ChunkId;
+
+#[derive(Debug, ::thiserror::Error)]
+pub enum Error {
+    #[error("Error::Io")]
+    Io(#[source] IoError),
+
+    #[error("Error::InvalidString")]
+    InvalidString(#[source] Utf8Error),
+
+    #[error("Error::UnexpectedMagicNumber: magic_number - {:?}", magic_number)]
+    UnexpectedMagicNumber { magic_number: [u8; 4] },
+
+    #[error("Error::UnexpectedFormType: form_type - {:?}", form_type)]
+    UnexpectedFormType { form_type: [u8; 4] },
+
+    #[error("Error::UnexpectedChunk: id - {:?}, expected - {:?}", id, expected)]
+    UnexpectedChunk { id: ChunkId, expected: ChunkId },
+}
+
+impl From<IoError> for Error {
+    fn from(e: IoError) -> Self {
+        Self::Io(e)
+    }
+}
+impl From<Utf8Error> for Error {
+    fn from(e: Utf8Error) -> Self {
+        Self::InvalidString(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,6 @@
 //! beam.to_file("my.beam").unwrap();
 //! ```
 
-
-
 mod beam_file;
 pub mod chunk;
 pub mod parts;
@@ -38,72 +36,5 @@ pub type StandardBeamFile = BeamFile<chunk::StandardChunk>;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug)]
-pub enum Error {
-    Io(std::io::Error),
-    InvalidString(std::str::Utf8Error),
-    UnexpectedMagicNumber { magic_number: [u8; 4] },
-    UnexpectedFormType { form_type: [u8; 4] },
-    UnexpectedChunk { id: chunk::Id, expected: chunk::Id },
-}
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Error::Io(ref x) => x.fmt(f),
-            Error::InvalidString(ref x) => x.fmt(f),
-            Error::UnexpectedMagicNumber { ref magic_number } => write!(
-                f,
-                r#"Unexpected magic number {} (expected b"FOR1")"#,
-                bytes_to_str(magic_number)
-            ),
-            Error::UnexpectedFormType { ref form_type } => write!(
-                f,
-                r#"Unexpected from type {} (expected b"BEAM")"#,
-                bytes_to_str(form_type)
-            ),
-            Error::UnexpectedChunk {
-                ref id,
-                ref expected,
-            } => write!(
-                f,
-                "Unexpected chunk id {} (expected {})",
-                bytes_to_str(id),
-                bytes_to_str(expected)
-            ),
-        }
-    }
-}
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref x) => x.description(),
-            Error::InvalidString(ref x) => x.description(),
-            Error::UnexpectedMagicNumber { .. } => "Unexpected magic number",
-            Error::UnexpectedFormType { .. } => "Unexpected form type",
-            Error::UnexpectedChunk { .. } => "Unexpected chunk",
-        }
-    }
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            Error::Io(ref x) => Some(x),
-            Error::InvalidString(ref x) => Some(x),
-            _ => None,
-        }
-    }
-}
-impl std::convert::From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Error::Io(err)
-    }
-}
-impl std::convert::From<std::str::Utf8Error> for Error {
-    fn from(err: std::str::Utf8Error) -> Self {
-        Error::InvalidString(err)
-    }
-}
-
-fn bytes_to_str(bytes: &[u8]) -> String {
-    std::str::from_utf8(bytes)
-        .map(|x| format!("b{:?}", x))
-        .unwrap_or_else(|_| format!("{:?}", bytes))
-}
+mod error;
+pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod beam_file;
 pub mod chunk;
 pub mod parts;
 
-pub use beam_file::BeamFile;
+pub use crate::beam_file::BeamFile;
 pub type RawBeamFile = BeamFile<chunk::RawChunk>;
 pub type StandardBeamFile = BeamFile<chunk::StandardChunk>;
 
@@ -83,7 +83,7 @@ impl std::error::Error for Error {
             Error::UnexpectedChunk { .. } => "Unexpected chunk",
         }
     }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::Io(ref x) => Some(x),
             Error::InvalidString(ref x) => Some(x),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 //! let beam = RawBeamFile{chunks: vec![chunk]};
 //! beam.to_file("my.beam").unwrap();
 //! ```
-extern crate byteorder;
-extern crate libflate;
+
+
 
 mod beam_file;
 pub mod chunk;
@@ -47,7 +47,7 @@ pub enum Error {
     UnexpectedChunk { id: chunk::Id, expected: chunk::Id },
 }
 impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             Error::Io(ref x) => x.fmt(f),
             Error::InvalidString(ref x) => x.fmt(f),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -198,10 +198,10 @@ impl chunk::Chunk for EncodeTestChunk {
     {
         use self::EncodeTestChunk::*;
         match id {
-            b"LitT" => Ok(Other(r#try!(chunk::RawChunk::decode_data(id, reader)))),
-            _ => Ok(Idempotent(r#try!(chunk::StandardChunk::decode_data(
+            b"LitT" => Ok(Other(chunk::RawChunk::decode_data(id, reader)?)),
+            _ => Ok(Idempotent(chunk::StandardChunk::decode_data(
                 id, reader
-            )))),
+            )?)),
         }
     }
     fn encode_data<W: Write>(&self, writer: W) -> Result<()> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -198,8 +198,8 @@ impl chunk::Chunk for EncodeTestChunk {
     {
         use self::EncodeTestChunk::*;
         match id {
-            b"LitT" => Ok(Other(try!(chunk::RawChunk::decode_data(id, reader)))),
-            _ => Ok(Idempotent(try!(chunk::StandardChunk::decode_data(
+            b"LitT" => Ok(Other(r#try!(chunk::RawChunk::decode_data(id, reader)))),
+            _ => Ok(Idempotent(r#try!(chunk::StandardChunk::decode_data(
                 id, reader
             )))),
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,3 @@
-
-
 use beam_file::chunk;
 use beam_file::chunk::Chunk;
 use beam_file::parts;
@@ -46,7 +44,8 @@ fn standard_chunks() {
                     } else {
                         None
                     }
-                }).nth(0)
+                })
+                .nth(0)
                 .unwrap()
         };
     }
@@ -199,9 +198,7 @@ impl chunk::Chunk for EncodeTestChunk {
         use self::EncodeTestChunk::*;
         match id {
             b"LitT" => Ok(Other(chunk::RawChunk::decode_data(id, reader)?)),
-            _ => Ok(Idempotent(chunk::StandardChunk::decode_data(
-                id, reader
-            )?)),
+            _ => Ok(Idempotent(chunk::StandardChunk::decode_data(id, reader)?)),
         }
     }
     fn encode_data<W: Write>(&self, writer: W) -> Result<()> {
@@ -219,7 +216,8 @@ fn encode_chunks() {
     std::io::copy(
         &mut File::open(test_file("test.beam")).unwrap(),
         &mut original,
-    ).unwrap();
+    )
+    .unwrap();
 
     let beam = BeamFile::<EncodeTestChunk>::from_reader(std::io::Cursor::new(&original)).unwrap();
     let mut encoded = Vec::new();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-extern crate beam_file;
+
 
 use beam_file::chunk;
 use beam_file::chunk::Chunk;


### PR DESCRIPTION
1) replaced the usages of `try!` macro with the more contemporary `?` operator;
2) redefined the `crate::Error` with `thiserror::Error` derive-macro;
3) updated `libflate` dependency.