### PR TITLE
Changed AtomChunk.is_unicode to pub

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -96,7 +96,7 @@ impl Chunk for RawChunk {
 #[derive(Debug, PartialEq, Eq)]
 pub struct AtomChunk {
     // Whether or not this Atom chunk contains UTF-8 atoms
-    is_unicode: bool,
+    pub is_unicode: bool,
     /// The list of atoms contained in a BEAM file.
     pub atoms: Vec<parts::Atom>,
 }


### PR DESCRIPTION
Hey there,

first, thanks a lot for all your awesome rust libs around beam and erlang, they are very helpful!
We are currently toying around with our own language targeting beam and want to construct beam files using this lib. However, we can't create AtomChunks as the field is_unicode isn't public.
Would you mind accepting this change? 
Was there any reason why the field was private?

Thanks a lot in advance for your time and effort!